### PR TITLE
hotfix: Python 3.12 set as standard requirement for backend

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.12'
           
       - name: Install uv
         run: pip install uv

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.12-slim
 WORKDIR /app
 
 # Update pip

--- a/docs/setup/local.md
+++ b/docs/setup/local.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 - Docker and Docker Compose
 - Bun 1.0+
-- Python 3.13+
+- Python 3.12+
 - uv package manager
 - Poppler Utils
 - Github CLI (optional, for artifact pulls)


### PR DESCRIPTION
 - Documentation updated
 - CI/CD workflows updated